### PR TITLE
Add dark mode and colorized output sections to the utilities document

### DIFF
--- a/Utilities.md
+++ b/Utilities.md
@@ -30,6 +30,8 @@ cls :- write('\e[2J').
 
 ```prolog
 :- use_module(library(theme/dark)).
+% Or in the terminal/console
+?- use_module(library(theme/dark)).
 ```
 
 ## Comments

--- a/Utilities.md
+++ b/Utilities.md
@@ -9,6 +9,17 @@
 ?- X is 3 + 5, write(X).
 ```
 
+### With colors
+
+```prolog
+?- ansi_format([fg(red)], 'This is in red', []).
+% black, red, green, yellow, blue, magenta, cyan, white
+?- ansi_format([bg(cyan)], 'This has a cyan background', []).
+?- ansi_format([bg(cyan),fg(magenta),bold], 'We can mix them', []).
+% reset, bold, fg(Color), bg(Color),...
+?- ansi_format([italic], 'This also formats the string (~w = 5)', [5]).
+```
+
 ## Clear the console
 
 ```prolog

--- a/Utilities.md
+++ b/Utilities.md
@@ -17,7 +17,7 @@
 ?- ansi_format([bg(cyan)], 'This has a cyan background', []).
 ?- ansi_format([bg(cyan),fg(magenta),bold], 'We can mix them', []).
 % reset, bold, fg(Color), bg(Color),...
-?- ansi_format([italic], 'This also formats the string (~w = 5)', [5]).
+?- ansi_format([], 'This also formats the string (~w = 5)', [5]).
 ```
 
 ## Clear the console

--- a/Utilities.md
+++ b/Utilities.md
@@ -15,6 +15,12 @@
 cls :- write('\e[2J').
 ```
 
+## Enable dark mode
+
+```prolog
+:- use_module(library(theme/dark)).
+```
+
 ## Comments
 ```prolog
 % Single line comment 


### PR DESCRIPTION
## Description
<!--- Describe your changes, What problem does it solve? -->

### Added a section on using dark mode in the swi-prolog console

![swi-prolog console in dark mode](https://user-images.githubusercontent.com/6272475/172136589-337f7e65-89b3-4a9d-b0fc-ae5b892357fc.png)

### Added a section on writing to the console with colors

![swi-prolog console with colored output](https://user-images.githubusercontent.com/6272475/172136905-5bafa1ba-a88b-4484-879a-d1d661582939.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Tested the changes locally on prolog command-line.
- [x] Updated documentation.

